### PR TITLE
i2c: Fix queue depth bug

### DIFF
--- a/I2CMaster.c
+++ b/I2CMaster.c
@@ -264,7 +264,7 @@ int32_t I2CMaster_TransferSequentialAsync_UserData(
     }
 
     // It's up to the user to group transfers of the same type
-    if (count >= MT3620_I2C_QUEUE_DEPTH) {
+    if (count > MT3620_I2C_QUEUE_DEPTH) {
         return ERROR_UNSUPPORTED;
     }
 


### PR DESCRIPTION
This was a bug as we never thought to test more than 2 consecutive
accesses. The mediatek drivers limit the transaction count to 2 on
purpose, but after testing we've confirmed that the HW supports a
queue length of 3.

Resolves: issue #21