### PR TITLE
Added UART_IsWriteComplete() function

### DIFF
--- a/UART.c
+++ b/UART.c
@@ -327,6 +327,11 @@ int32_t UART_Write(UART *handle, const void *data, uintptr_t size)
     return ERROR_NONE;
 }
 
+inline bool UART_IsWriteComplete(UART *handle)
+{
+    return MT3620_UART_FIELD_READ(handle->id, lsr, temt);
+}
+
 int32_t UART_Read(UART *handle, void *data, uintptr_t size)
 {
     if (!handle) {

--- a/UART.h
+++ b/UART.h
@@ -7,6 +7,7 @@
 #include "Platform.h"
 #include "Common.h"
 #include <stdint.h>
+#include <stdbool.h>
 
 
 #ifdef __cplusplus
@@ -70,6 +71,13 @@ void UART_Close(UART *handle);
 /// <param name="size">Size of the data in bytes.</param>
 /// <returns>ERROR_NONE on success, or an error code.</returns>
 int32_t UART_Write(UART *handle, const void *data, uintptr_t size);
+
+/// <summary>
+/// This function checks if the UART's hardware TX buffer is actually empty.
+/// </summary>
+/// <param name="handle">Which UART to read TX buffer status from.</param>
+/// <returns>'true' if the UART's hardware TX buffer is empty, 'false' otherwise.</returns>
+bool UART_IsWriteComplete(UART *handle);
 
 /// <summary>
 /// This function blocks until it has read size bytes from the UART.


### PR DESCRIPTION
Checks if the UART's hardware TX buffer is actually empty. Useful in applications where actions need to be taken no earlier than when the last byte is effectively transmitted (i.e. RS-485 applications, etc.).