### PR TITLE
Flow control

### DIFF
--- a/UART.c
+++ b/UART.c
@@ -143,45 +143,7 @@ UART *UART_Open(Platform_Unit unit, unsigned baud, UART_Parity parity, unsigned 
         // restore previous lcr (0xBF)
         mt3620_uart[id]->lcr = lcr.mask;
     }
-     
-#if 0
-    mt3620_uart[id]->lcr = 0xBF;
 
-    // EFR (enable enhancement features)
-    // mt3620_uart_efr_t efr = { .mask = mt3620_uart[id]->efr };
-    // efr.sw_flow_cont = false;//enableFlowControl ? 0b1010 : 0;
-    // efr.enable_e     = true;
-    // efr.auto_rts     = enableFlowControl;
-    // efr.auto_cts     = enableFlowControl;
-    mt3620_uart[id]->efr = 0xd0;
-
-
-    mt3620_uart[id]->escape_en = 0;
-
-    mt3620_uart[id]->lcr = 0;
-
-    mt3620_uart[id]->mcr = 0x2;
-
-    mt3620_uart[id]->lcr = lcr.mask;
-#endif
-#if 0
-    mt3620_uart[id]->lcr = 0xBF;
-
-    // EFR (enable enhancement features)
-    mt3620_uart_efr_t efr = { .mask = mt3620_uart[id]->efr };
-    efr.sw_flow_cont = false;//enableFlowControl ? 0b1010 : 0;
-    efr.enable_e     = true;
-    efr.auto_rts     = enableFlowControl;
-    efr.auto_cts     = enableFlowControl;
-    mt3620_uart[id]->efr = efr.mask;
-
-    if (enableFlowControl) {
-        // mcr requires lcr to be set to 0xBF
-        mt3620_uart_mcr_t mcr = { .mask = mt3620_uart[id]->mcr };
-        mcr.rts = true;
-        mt3620_uart[id]->mcr = mcr.mask;
-    }
-#endif
     MT3620_UART_FIELD_WRITE(id, highspeed, speed, 3);
     MT3620_UART_FIELD_WRITE(id, dlm, dlm, (dl >> 8)); // Divisor Latch (MS)
     MT3620_UART_FIELD_WRITE(id, dll, dll, (dl & 0xFF)); // Divisor Latch (LS)

--- a/UART.c
+++ b/UART.c
@@ -137,7 +137,7 @@ UART *UART_Open(Platform_Unit unit, unsigned baud, UART_Parity parity, unsigned 
     lcr.dlab = true;
     mt3620_uart[id]->lcr = lcr.mask;
 
-     // EFR (enable enhancement features)
+    // EFR (enable enhancement features)
     mt3620_uart_efr_t efr = { .mask = mt3620_uart[id]->efr };
     efr.sw_flow_cont = false;
     efr.enable_e     = true;
@@ -449,7 +449,7 @@ static void UART_HandleIRQ(Platform_Unit unit)
     }
 
     mt3620_uart_iir_id_e iirId;
-    do {        
+    do {
         // Interrupt Identification Register
         iirId = MT3620_UART_FIELD_READ(handle->id, iir, iir_id);
         switch (iirId) {
@@ -488,6 +488,7 @@ static void UART_HandleIRQ(Platform_Unit unit)
             if (handle->rxCallback && UART_ReadAvailable(handle) > 0) {
                 handle->rxCallback();
             }
+
             mt3620_uart[handle->id]->vfifo_en; // reading this acknowledges timeout interrupt
             break;
 

--- a/UART.c
+++ b/UART.c
@@ -30,6 +30,7 @@
 #error "RX buffer size must be a power of two"
 #endif
 
+
 // Note that we currently reserve an RX and TX buffer in sysram for each possible
 // ISU interface. For very sysram constrained applications it may make sense to
 // modify this so that you only reserve the buffers that are actually needed.
@@ -69,7 +70,7 @@ int UART_HW_FlowControl_Enable(UART *handle, bool enableFlowControl)
     mt3620_uart_lcr_t lcr = { .mask = mt3620_uart[handle->id]->lcr };
     mt3620_uart[handle->id]->lcr = 0xBF;
 
-     // EFR (enable enhancement features)
+    // EFR (enable enhancement features)
     mt3620_uart_efr_t efr = { .mask = mt3620_uart[id]->efr };
     efr.sw_flow_cont = false;
     efr.enable_e     = true;
@@ -447,13 +448,10 @@ static void UART_HandleIRQ(Platform_Unit unit)
         return;
     }
 
-
     mt3620_uart_iir_id_e iirId;
-    do {
-        
+    do {        
         // Interrupt Identification Register
         iirId = MT3620_UART_FIELD_READ(handle->id, iir, iir_id);
-
         switch (iirId) {
         case MT3620_UART_IIR_ID_NO_INTERRUPT_PENDING:
             // The TX FIFO can accept more data.

--- a/UART.h
+++ b/UART.h
@@ -41,6 +41,7 @@ static const uint32_t UART_PRIORITY = 2;
 /// <param name="baud">Target baud rate.</param>
 /// <param name="parity">Parity mode: <see cref="UART_Parity" />.</param>
 /// <param name="stopBits">Number of stop bits, only 1 or 2 are valid.</param>
+/// <param name="enableFlowControl">Set to true to enable hardware flow control.</param>
 /// <param name="rxCallback">An optional callback to invoke when the UART receives data.
 /// This can be NULL if the application does not want to read any data from the UART. The
 /// application should call <see cref="UART_DequeueData" /> to retrieve the data.</param>
@@ -49,6 +50,7 @@ UART *UART_Open(
     unsigned      baud,
     UART_Parity   parity,
     unsigned      stopBits,
+    bool          enableFlowControl,
     void         (*rxCallback)(void));
 
 /// <summary>
@@ -94,6 +96,8 @@ int32_t UART_Read(UART *handle, void *data, uintptr_t size);
 /// <param name="handle">Which UART to read the read buffer size of.</param>
 /// <returns>Number of bytes available to be read.</returns>
 uintptr_t UART_ReadAvailable(UART *handle);
+
+int UART_hw_fc(UART *handle, bool enable);
 
 
 #ifdef __cplusplus

--- a/UART.h
+++ b/UART.h
@@ -41,7 +41,6 @@ static const uint32_t UART_PRIORITY = 2;
 /// <param name="baud">Target baud rate.</param>
 /// <param name="parity">Parity mode: <see cref="UART_Parity" />.</param>
 /// <param name="stopBits">Number of stop bits, only 1 or 2 are valid.</param>
-/// <param name="enableFlowControl">Set to true to enable hardware flow control.</param>
 /// <param name="rxCallback">An optional callback to invoke when the UART receives data.
 /// This can be NULL if the application does not want to read any data from the UART. The
 /// application should call <see cref="UART_DequeueData" /> to retrieve the data.</param>
@@ -50,7 +49,6 @@ UART *UART_Open(
     unsigned      baud,
     UART_Parity   parity,
     unsigned      stopBits,
-    bool          enableFlowControl,
     void         (*rxCallback)(void));
 
 /// <summary>
@@ -97,8 +95,12 @@ int32_t UART_Read(UART *handle, void *data, uintptr_t size);
 /// <returns>Number of bytes available to be read.</returns>
 uintptr_t UART_ReadAvailable(UART *handle);
 
-int UART_hw_fc(UART *handle, bool enable);
-
+/// <summary>
+/// This function enables/disables hardware flow control.
+/// </summary>
+/// <param name="handle">Which UART to enable flow control.</param>
+/// <returns>ERROR_NONE on success, or ERROR_PARAMETER is debug UART is given.</returns>
+int UART_HW_FlowControl_Enable(UART *handle, bool enableFlowControl);
 
 #ifdef __cplusplus
  }

--- a/UART.h
+++ b/UART.h
@@ -99,7 +99,7 @@ uintptr_t UART_ReadAvailable(UART *handle);
 /// This function enables/disables hardware flow control.
 /// </summary>
 /// <param name="handle">Which UART to enable flow control.</param>
-/// <returns>ERROR_NONE on success, or ERROR_PARAMETER is debug UART is given.</returns>
+/// <returns>ERROR_NONE on success, or ERROR_PARAMETER if debug UART is given.</returns>
 int UART_HW_FlowControl_Enable(UART *handle, bool enableFlowControl);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Introduce `UART_HW_FlowControl_Enable` function to enable/disable hardware RTS/CTS support. RTS/CTS functionality has been tested with an off-the-shelf RS232 adapter, and through connecting two MT3620 development boards together. Operation was validated using a logic analyser. Test code can be supplied on request!